### PR TITLE
docs: Fixed name of libc++abi not libc++adb

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ On Linux/macOS/Android(Termux), it requires clang, or gcc.
 On an Ubuntu machine you can install the dependencies with the following command:
 
 ```console
-$ sudo apt install build-essential clang lld libc++-dev libc++adb-dev
+$ sudo apt install build-essential clang lld libc++-dev libc++abi-dev
 ```
 
 ### Windows


### PR DESCRIPTION
Hey @f04ever,

Like I said, more of the same small fixes.

I'll leave it alone for today, maybe look at it with better eyes tomorrow.

Cheers,
Gus